### PR TITLE
feat: secure settings with env fallbacks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,20 @@
+# Python
+__pycache__/
+*.pyc
+
+# Virtual environments
+**/venv/
+
+# Runtime files
+**/media/
+**/staticfiles/
+
+# Node modules
+**/node_modules/
+
+# Environment files
+.env
+autoenv
+
+# OS artifacts
+.DS_Store


### PR DESCRIPTION
## Summary
- guard SSM parameter lookups and default to environment values
- switch Django settings to environment-driven debug, hosts, CORS, and CSRF with safe defaults
- remove hard-coded OAuth secrets and push token
- default email host, Celery connections, redirect URL, and frontend base URL for local setup
- add gitignore for venv, media, staticfiles, and node_modules

## Testing
- `venv/bin/python manage.py test` *(fails: ModuleNotFoundError: No module named 'celery')*

------
https://chatgpt.com/codex/tasks/task_e_68999ddb6b0083239402a01e24d920b1