### PR TITLE
Add admin initialization script

### DIFF
--- a/MinMin BE/init_admin_user.py
+++ b/MinMin BE/init_admin_user.py
@@ -1,0 +1,19 @@
+import os
+import django
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'alpha.settings')
+django.setup()
+
+from django.contrib.auth import get_user_model
+
+User = get_user_model()
+
+admin_email = os.environ.get('DJANGO_SUPERUSER_EMAIL', 'admin@example.com')
+admin_password = os.environ.get('DJANGO_SUPERUSER_PASSWORD', 'adminpass')
+admin_name = os.environ.get('DJANGO_SUPERUSER_NAME', 'Admin')
+
+if not User.objects.filter(email=admin_email).exists():
+    User.objects.create_superuser(email=admin_email, password=admin_password, full_name=admin_name)
+    print('Admin user created.')
+else:
+    print('Admin user already exists.')

--- a/README.md
+++ b/README.md
@@ -26,9 +26,10 @@ MinMin is a full-stack platform for restaurant ordering and management. The back
    pip install -r requirements.txt
    ```
 3. Provide required environment variables such as `SECRET_KEY`, database credentials (`DB_NAME`, `DB_USER`, `DB_PASSWORD`, `DB_HOST`, `DB_PORT`) and any email/OAuth keys referenced in `alpha/settings.py`.
-4. Apply migrations and start the development server:
+4. Apply migrations, initialize an admin user, and start the development server:
    ```bash
    python manage.py migrate
+   python init_admin_user.py
    python manage.py runserver
    ```
 5. Optional services:


### PR DESCRIPTION
## Summary
- add `init_admin_user.py` to create a superuser from environment variables
- document running the script during backend setup

## Testing
- `python manage.py test accounts` *(fails: Could not find the GDAL library)*

------
https://chatgpt.com/codex/tasks/task_e_6899ef69d8548323a8e95856d5a6fb73