### PR TITLE
feat: apply front-end styling to Django admin

### DIFF
--- a/MinMin BE/static/css/custom_admin.css
+++ b/MinMin BE/static/css/custom_admin.css
@@ -1,6 +1,54 @@
 /* static/css/custom_admin.css */
-body {
-  background: linear-gradient(135deg, #6a11cb 0%, #2575fc 100%);
+
+/* Color palette inspired by the FE apps */
+:root {
+  --primary-color: #91B275;
+  --primary-hover: #708e5e;
+  --text-dark: #40392B;
+}
+
+/* Global admin overrides */
+#header {
+  background-color: var(--primary-color);
+}
+
+#header #branding h1,
+#header #branding h1 a:link,
+#header #branding h1 a:visited {
+  color: #fff;
+}
+
+#header .admin-logo {
+  height: 40px;
+  margin-right: 10px;
+  vertical-align: middle;
+}
+
+a:link,
+a:visited {
+  color: var(--primary-color);
+}
+
+button,
+input[type="submit"],
+.button,
+.submit-row input {
+  background-color: var(--primary-color);
+  border-color: var(--primary-color);
+  color: #fff;
+}
+
+button:hover,
+input[type="submit"]:hover,
+.button:hover,
+.submit-row input:hover {
+  background-color: var(--primary-hover);
+  border-color: var(--primary-hover);
+}
+
+/* Login page styling */
+body.login {
+  background: linear-gradient(135deg, var(--primary-color) 0%, #50693A 100%);
   color: #ffffff;
   font-family: Arial, sans-serif;
   margin: 0;
@@ -18,7 +66,7 @@ body {
   box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
   width: 100%;
   max-width: 400px;
-  color: #333333;
+  color: var(--text-dark);
 }
 
 .login-header {
@@ -50,7 +98,7 @@ body {
 }
 
 .btn-login {
-  background-color: #6a11cb;
+  background-color: var(--primary-color);
   color: white;
   padding: 10px;
   width: 100%;
@@ -61,7 +109,7 @@ body {
 }
 
 .btn-login:hover {
-  background-color: #2575fc;
+  background-color: var(--primary-hover);
 }
 
 .reset-password {
@@ -70,7 +118,7 @@ body {
 }
 
 .reset-password a {
-  color: #6a11cb;
+  color: var(--primary-color);
   text-decoration: none;
 }
 

--- a/MinMin BE/templates/admin/base_site.html
+++ b/MinMin BE/templates/admin/base_site.html
@@ -1,0 +1,20 @@
+{% extends "admin/base.html" %}
+{% load static %}
+
+{% block title %}{{ site_title|default:_('Django site admin') }}{% endblock %}
+
+{% block extrastyle %}
+  {{ block.super }}
+  <link rel="stylesheet" type="text/css" href="{% static 'css/custom_admin.css' %}">
+{% endblock %}
+
+{% block branding %}
+  <h1 id="site-name">
+    <a href="{% url 'admin:index' %}">
+      <img src="{% static 'images/logo.png' %}" alt="Logo" class="admin-logo">
+      {{ site_header|default:_('Django administration') }}
+    </a>
+  </h1>
+{% endblock %}
+
+{% block nav-global %}{% endblock %}

--- a/MinMin BE/templates/admin/login.html
+++ b/MinMin BE/templates/admin/login.html
@@ -1,11 +1,7 @@
-{% extends "admin/base_site.html" %} {% load static i18n %} {% block title %}
-Alpha Admin Login {% endblock %} {% block extrahead %}
-<link
-  rel="stylesheet"
-  type="text/css"
-  href="{% static 'css/custom_admin.css' %}"
-/>
-{% endblock %} {% block content %}
+{% extends "admin/base_site.html" %}
+{% load static i18n %}
+{% block title %}Alpha Admin Login {% endblock %}
+{% block content %}
 <div class="custom-login-container">
   <div class="login-header">
     <img src="{% static 'images/logo.png' %}" alt="Logo" class="logo" />


### PR DESCRIPTION
## Summary
- style Django admin with FE color palette and logo
- simplify admin login template to use shared branding

## Testing
- `python manage.py test` *(fails: Could not find the GDAL library)*

------
https://chatgpt.com/codex/tasks/task_e_689b01e8d99c83238737927ed416fdf6