### PR TITLE
feat: enable hermes and shrink builds

### DIFF
--- a/MinMin FE Customer/app.json
+++ b/MinMin FE Customer/app.json
@@ -8,6 +8,7 @@
     "scheme": "alphacustomer",
     "userInterfaceStyle": "automatic",
     "newArchEnabled": true,
+    "jsEngine": "hermes",
     "ios": {
       "supportsTablet": true,
       "infoPlist": {
@@ -75,7 +76,19 @@
         }
       ],
       "expo-web-browser",
-      "expo-localization"
+      "expo-localization",
+      [
+        "expo-build-properties",
+        {
+          "android": {
+            "enableProguardInReleaseBuilds": true,
+            "enableShrinkResourcesInReleaseBuilds": true
+          },
+          "ios": {
+            "useFrameworks": "static"
+          }
+        }
+      ]
     ],
     "experiments": {
       "typedRoutes": true

--- a/MinMin FE Resturant/app.json
+++ b/MinMin FE Resturant/app.json
@@ -8,6 +8,7 @@
     "scheme": "myapp",
     "userInterfaceStyle": "automatic",
     "newArchEnabled": true,
+    "jsEngine": "hermes",
     "ios": {
       "supportsTablet": true
     },
@@ -41,6 +42,18 @@
         "expo-image-picker",
         {
           "photosPermission": "The app accesses your photos to let you share them with your friends."
+        }
+      ],
+      [
+        "expo-build-properties",
+        {
+          "android": {
+            "enableProguardInReleaseBuilds": true,
+            "enableShrinkResourcesInReleaseBuilds": true
+          },
+          "ios": {
+            "useFrameworks": "static"
+          }
         }
       ]
     ],


### PR DESCRIPTION
## Summary
- enable Hermes JS engine for customer and restaurant apps
- shrink Android resources and enable Proguard via expo-build-properties

## Testing
- `npm test` (customer, fails: Missing script)
- `npm test -- --watchAll=false` (restaurant)

------
https://chatgpt.com/codex/tasks/task_e_689afc2209b883239fd69b3666151ee9