### PR TITLE
fix: replace expo-audio with expo-av

### DIFF
--- a/MinMinFECustomer/app/(protected)/restaurant/(branch)/index.tsx
+++ b/MinMinFECustomer/app/(protected)/restaurant/(branch)/index.tsx
@@ -27,7 +27,7 @@ import {
   useGetRelatedMenus,
   useSearchMenuAvailabilities,
 } from "@/services/mutation/menuMutation";
-import { Audio } from "expo-audio";
+import { Audio } from "expo-av";
 import { useCreateAWaiterCall } from "@/services/mutation/branchMutation";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { DishRow } from "@/components/restaurant/Dish";

--- a/MinMinFECustomer/package.json
+++ b/MinMinFECustomer/package.json
@@ -23,7 +23,7 @@
     "dayjs": "^1.11.13",
     "expo": "53.0.20",
     "expo-auth-session": "~6.2.1",
-    "expo-audio": "~14.0.4",
+    "expo-av": "~15.1.7",
     "expo-blur": "~14.1.5",
     "expo-camera": "~16.1.11",
     "expo-constants": "~17.1.6",


### PR DESCRIPTION
## Summary
- replace nonexistent expo-audio with expo-av
- update restaurant screen to import Audio from expo-av

## Testing
- `npm install --dry-run`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689b181801808323b201e77317b03d31