### PR TITLE
fix: ensure BASE_URL uses supported URL scheme

### DIFF
--- a/MinMinFECustomer/utils/constants.ts
+++ b/MinMinFECustomer/utils/constants.ts
@@ -37,7 +37,15 @@ export const FACEBOOK_REDIRECT_URI = `${process.env.EXPO_PUBLIC_BASE_URL}/api/au
 export const FACEBOOK_AUTH_URL = "https://www.facebook.com/v11.0/dialog/oauth";
 
 // Environment Constants
-export const BASE_URL = process.env.EXPO_PUBLIC_BASE_URL;
+// Ensure BASE_URL always has a valid HTTP/HTTPS scheme so that
+// authentication sessions opened in the iOS web browser do not crash
+// with "unsupported scheme" errors.
+const rawBaseUrl = process.env.EXPO_PUBLIC_BASE_URL || "";
+export const BASE_URL = rawBaseUrl.startsWith("http://") || rawBaseUrl.startsWith("https://")
+  ? rawBaseUrl
+  : rawBaseUrl
+  ? `https://${rawBaseUrl}`
+  : "";
 export const APP_SCHEME = process.env.EXPO_PUBLIC_SCHEME;
 export const JWT_SECRET = process.env.JWT_SECRET!;
 


### PR DESCRIPTION
## Summary
- ensure BASE_URL always includes http/https scheme to avoid unsupported URL errors during Google login

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unable to resolve path to module 'react-test-renderer'; 81 problems)*

------
https://chatgpt.com/codex/tasks/task_e_689b2b82e8388323aba54d29117e08ba