### PR TITLE
Align bowl subtotal and fix checkout layout

### DIFF
--- a/MinMinFECustomer/app/(protected)/cart/index.tsx
+++ b/MinMinFECustomer/app/(protected)/cart/index.tsx
@@ -181,12 +181,6 @@ export default function CartScreen() {
                         <Text variant="titleMedium" style={styles.dishName}>
                           {dish.name}
                         </Text>
-                        <Text
-                          variant="bodySmall"
-                          style={styles.dishDescription}
-                        >
-                          {dish.description}
-                        </Text>
                         <View style={styles.priceContainer}>
                           <View style={styles.quantityContainer}>
                             <IconButton
@@ -270,9 +264,8 @@ export default function CartScreen() {
                   theme={{ colors: { primary: "#9AC26B" } }}
                 >
                   {isProcessing
-                    ? i18n.t("checking_discount_button") // Replaced hardcoded string
-                    : i18n.t("checkout_button")}{" "}
-                  {/* Replaced hardcoded string */}
+                    ? i18n.t("checking_discount_button")
+                    : `${i18n.t("checkout_button")} • ${subtotal.toFixed(2)} ${i18n.t("currency_unit")}`}
                 </Button>
                 </View>
               </ScrollView>
@@ -368,10 +361,6 @@ const styles = StyleSheet.create({
   dishName: {
     color: "#333",
     fontWeight: "bold",
-    marginBottom: 4,
-  },
-  dishDescription: {
-    color: "#666",
     marginBottom: 4,
   },
   dishPrice: {

--- a/MinMinFECustomer/app/(protected)/checkOut/index.tsx
+++ b/MinMinFECustomer/app/(protected)/checkOut/index.tsx
@@ -359,6 +359,8 @@ export default function CheckoutScreen() {
                   </List.Subheader>
                 </View>
               </View>
+            </ScrollView>
+            <View style={styles.fixedBottom}>
               <View style={styles.paymentCard}>
                 <Card.Title
                   title={i18n.t("payment_method_title")} // Replaced hardcoded string
@@ -502,11 +504,11 @@ export default function CheckoutScreen() {
                   }}
                   theme={{ colors: { primary: "#9AC26B" } }}
                 >
-                  {i18n.t("place_order_button")}{" "}
+                  {i18n.t("place_order_button")}
                   {/* Replaced hardcoded string */}
                 </Button>
               )}
-            </ScrollView>
+            </View>
           </KeyboardAvoidingView>
         </Animated.View>
 
@@ -685,7 +687,13 @@ const styles = StyleSheet.create({
   },
   scrollContent: {
     padding: Platform.OS === "web" ? 5 : 3,
-    paddingBottom: Platform.OS === "ios" ? 120 : 60, // Extra space for iOS safe area
+    paddingBottom: 20,
+  },
+  fixedBottom: {
+    borderTopWidth: 1,
+    borderTopColor: "#eee",
+    padding: 16,
+    backgroundColor: "#FDFDFC",
   },
   card: {
     marginBottom: 16,


### PR DESCRIPTION
## Summary
- Hide dish descriptions in the bowl and show the subtotal directly on the checkout button
- Anchor payment method selection and place-order button at the bottom of the order summary screen

## Testing
- `npm run lint` *(fails: Unable to resolve path to module 'react-test-renderer')*
- `npm install react-test-renderer` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689b3a001e948323952bb0a5b1508999