### PR TITLE
Apply caching across restaurant API endpoints

### DIFF
--- a/MinMinBE/alpha/settings.py
+++ b/MinMinBE/alpha/settings.py
@@ -275,6 +275,13 @@ else:
         }
     }
 
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.redis.RedisCache',
+        'LOCATION': 'redis://127.0.0.1:6379/1',
+    }
+}
+
 
 # Password validation
 # https://docs.djangoproject.com/en/5.1/ref/settings/#auth-password-validators

--- a/MinMinBE/core/cache.py
+++ b/MinMinBE/core/cache.py
@@ -1,0 +1,30 @@
+from django.core.cache import cache
+from rest_framework import viewsets
+from rest_framework.response import Response
+
+
+class CachedModelViewSet(viewsets.ModelViewSet):
+    """ModelViewSet with basic per-user response caching for GET requests."""
+    cache_timeout = 300  # seconds
+
+    def _cache_key(self, request, *args, **kwargs):
+        user_id = getattr(request.user, 'id', 'anon')
+        return f"{user_id}:{request.get_full_path()}"
+
+    def list(self, request, *args, **kwargs):
+        key = self._cache_key(request, *args, **kwargs)
+        data = cache.get(key)
+        if data is not None:
+            return Response(data)
+        response = super().list(request, *args, **kwargs)
+        cache.set(key, response.data, self.cache_timeout)
+        return response
+
+    def retrieve(self, request, *args, **kwargs):
+        key = self._cache_key(request, *args, **kwargs)
+        data = cache.get(key)
+        if data is not None:
+            return Response(data)
+        response = super().retrieve(request, *args, **kwargs)
+        cache.set(key, response.data, self.cache_timeout)
+        return response

--- a/MinMinBE/restaurant/branch/views.py
+++ b/MinMinBE/restaurant/branch/views.py
@@ -1,8 +1,7 @@
-from rest_framework import viewsets,status
+from rest_framework import status
 from django.core.exceptions import ValidationError
 from accounts.permissions import HasCustomAPIKey
 from django_filters.rest_framework import DjangoFilterBackend
-from django.core.cache import cache
 from rest_framework.response import Response
 from rest_framework.permissions import IsAuthenticated
 from .models import Branch
@@ -16,11 +15,12 @@ from rest_framework.decorators import action
 from restaurant.table.models import Table
 from channels.layers import get_channel_layer
 from asgiref.sync import async_to_sync
+from core.cache import CachedModelViewSet
 
 class BranchPagination(PageNumberPagination):
     page_size = 10
 
-class BranchView(viewsets.ModelViewSet):
+class BranchView(CachedModelViewSet):
     permission_classes = [IsAuthenticated,HasCustomAPIKey]
     queryset = Branch.objects.all()
     serializer_class = BranchSerializer

--- a/MinMinBE/restaurant/combo/views.py
+++ b/MinMinBE/restaurant/combo/views.py
@@ -1,18 +1,17 @@
-from rest_framework import viewsets
 from django_filters.rest_framework import DjangoFilterBackend
-from django.core.cache import cache 
 from rest_framework.pagination import PageNumberPagination
 from .models import Combo, ComboItem
 from .serializers import ComboSerializer, ComboItemSerializer
 from accounts.permissions import HasCustomAPIKey
 from rest_framework.permissions import IsAuthenticated
 from .comboFilter import ComboFilter,ComboItemFilter
+from core.cache import CachedModelViewSet
 
 class ComboPagination(PageNumberPagination):
     page_size = 10
 
 
-class ComboView(viewsets.ModelViewSet):
+class ComboView(CachedModelViewSet):
     permission_classes = [IsAuthenticated,HasCustomAPIKey]
     queryset = Combo.objects.all()
     serializer_class = ComboSerializer
@@ -33,7 +32,7 @@ class ComboItemPagination(PageNumberPagination):
     page_size = 10
 
 
-class ComboItemView(viewsets.ModelViewSet):
+class ComboItemView(CachedModelViewSet):
     permission_classes = [IsAuthenticated,HasCustomAPIKey]
     queryset = ComboItem.objects.all()
     serializer_class = ComboItemSerializer

--- a/MinMinBE/restaurant/discount/views.py
+++ b/MinMinBE/restaurant/discount/views.py
@@ -1,4 +1,4 @@
-from rest_framework import viewsets, filters
+from rest_framework import filters
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework.response import Response
 from django.core.exceptions import ValidationError
@@ -15,11 +15,12 @@ from accounts.permissions import HasCustomAPIKey,IsAdminOrRestaurant
 from .services import get_big_discount_items
 from restaurant.menu_availability.serializers import MenuAvailabilitySerializer
 from restaurant.tenant.models import Tenant
+from core.cache import CachedModelViewSet
 
 class DiscountPagination(PageNumberPagination):
     page_size = 10
 
-class DiscountViewSet(viewsets.ModelViewSet):
+class DiscountViewSet(CachedModelViewSet):
     permission_classes = [IsAuthenticated,HasCustomAPIKey]
     queryset = Discount.objects.all()
     serializer_class = DiscountSerializer
@@ -100,7 +101,7 @@ class DiscountViewSet(viewsets.ModelViewSet):
 class DiscountRulePagination(PageNumberPagination):
     page_size = 10
 
-class DiscountRuleViewSet(viewsets.ModelViewSet):
+class DiscountRuleViewSet(CachedModelViewSet):
     permission_classes = [IsAuthenticated,HasCustomAPIKey,IsAdminOrRestaurant]
     queryset = DiscountRule.objects.all()
     serializer_class = DiscountRuleSerializer
@@ -131,7 +132,7 @@ class DiscountRuleViewSet(viewsets.ModelViewSet):
 
 class DiscountApplicationPagination(PageNumberPagination):
     page_size = 10
-class DiscountApplicationViewSet(viewsets.ModelViewSet):
+class DiscountApplicationViewSet(CachedModelViewSet):
     permission_classes = [IsAuthenticated,HasCustomAPIKey,IsAdminOrRestaurant]
     queryset = DiscountApplication.objects.all()
     serializer_class = DiscountApplicationSerializer
@@ -153,7 +154,7 @@ class DiscountApplicationViewSet(viewsets.ModelViewSet):
 
 class CouponPagination(PageNumberPagination):
     page_size = 10
-class CouponViewSet(viewsets.ModelViewSet):
+class CouponViewSet(CachedModelViewSet):
     permission_classes = [IsAuthenticated,HasCustomAPIKey,IsAdminOrRestaurant]
     queryset = Coupon.objects.all()
     serializer_class = CouponSerializer

--- a/MinMinBE/restaurant/menu/views.py
+++ b/MinMinBE/restaurant/menu/views.py
@@ -1,21 +1,21 @@
-from rest_framework import viewsets, status
+from rest_framework import status
 from django.core.exceptions import ValidationError
 from rest_framework.response import Response
 from rest_framework.permissions import IsAuthenticated
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework.parsers import MultiPartParser, FormParser
 from django.db.models import Q
-from django.core.cache import cache 
 from rest_framework.pagination import PageNumberPagination
 from .models import Menu
 from .menuFilter import MenuFilter
 from .serializers import MenuSerializer
 from accounts.permissions import HasCustomAPIKey
+from core.cache import CachedModelViewSet
 
 class MenuViewPagination(PageNumberPagination):
     page_size = 10
 
-class MenuView(viewsets.ModelViewSet):
+class MenuView(CachedModelViewSet):
     permission_classes = [IsAuthenticated,HasCustomAPIKey]
     queryset = Menu.objects.all()
     serializer_class = MenuSerializer

--- a/MinMinBE/restaurant/menu_availability/views.py
+++ b/MinMinBE/restaurant/menu_availability/views.py
@@ -1,5 +1,5 @@
 import json
-from rest_framework import viewsets, status
+from rest_framework import status
 from rest_framework.response import Response
 from django.db.models import Q, Prefetch, Avg, Count # Import Avg, Count for potential future use
 from .models import MenuAvailability # Assuming your models are in the current app
@@ -22,6 +22,7 @@ from customer.feedback.models import Feedback # Assuming Feedback model is in 'c
 from django.core.cache import cache 
 from django.utils.decorators import method_decorator
 from django.views.decorators.cache import cache_page
+from core.cache import CachedModelViewSet
 
 # Define cache timeouts
 CACHE_TIMEOUT_LIST_QS_SECONDS = 60 * 5 # 5 minutes for main queryset
@@ -41,7 +42,7 @@ class MenuAvailabilityViewPagination(PageNumberPagination):
             'results': data
         })
 
-class MenuAvailabilityView(viewsets.ModelViewSet):
+class MenuAvailabilityView(CachedModelViewSet):
     permission_classes = [IsAuthenticated, HasCustomAPIKey]
     queryset = MenuAvailability.objects.all()
     serializer_class = MenuAvailabilitySerializer

--- a/MinMinBE/restaurant/qr_code/views.py
+++ b/MinMinBE/restaurant/qr_code/views.py
@@ -1,4 +1,3 @@
-from rest_framework.viewsets import ModelViewSet
 from rest_framework.response import Response
 from rest_framework import status
 from rest_framework.permissions import IsAuthenticated
@@ -9,19 +8,19 @@ from django.db.models import Q
 
 from alpha import settings
 from .models import QRCode
-from django.core.cache import cache 
 from rest_framework.pagination import PageNumberPagination
 from restaurant.table.models import Table
 from .serializers import QRCodeSerializer
 from .utils import generate_qr_code
 from accounts.permissions import HasCustomAPIKey, IsAdminOrRestaurant
+from core.cache import CachedModelViewSet
 
 import os
 import re
 class QRCodeViewPagination(PageNumberPagination):
     page_size = 10
 
-class QRCodeViewSet(ModelViewSet):
+class QRCodeViewSet(CachedModelViewSet):
     """
     A ViewSet for viewing and editing QR code instances.
     """

--- a/MinMinBE/restaurant/related_menu/views.py
+++ b/MinMinBE/restaurant/related_menu/views.py
@@ -1,6 +1,4 @@
-from rest_framework import viewsets
 from rest_framework.permissions import IsAuthenticated
-from django.core.cache import cache 
 from rest_framework.pagination import PageNumberPagination
 from django_filters.rest_framework import DjangoFilterBackend
 from accounts.permissions import HasCustomAPIKey
@@ -8,11 +6,12 @@ from django.db.models import Q
 from .models import RelatedMenuItem
 from .serializers import RelatedMenuItemSerializer
 from .relatedMenuItemFilter import RelatedMenuItemFilter
+from core.cache import CachedModelViewSet
 
 class RelatedMenuItemPagination(PageNumberPagination):
     page_size = 10
 
-class RelatedMenuItemView(viewsets.ModelViewSet):
+class RelatedMenuItemView(CachedModelViewSet):
     permission_classes = [IsAuthenticated,HasCustomAPIKey]
     queryset = RelatedMenuItem.objects.all()
     serializer_class = RelatedMenuItemSerializer

--- a/MinMinBE/restaurant/table/views.py
+++ b/MinMinBE/restaurant/table/views.py
@@ -1,6 +1,6 @@
 from django.core.exceptions import ValidationError
 from django_filters.rest_framework import DjangoFilterBackend
-from rest_framework import viewsets, status
+from rest_framework import status
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
@@ -9,13 +9,14 @@ from accounts.permissions import HasCustomAPIKey, IsAdminOrRestaurant
 from .models import Table
 from .serializers import TableSerializer
 from .tableFilter import TableFilter
+from core.cache import CachedModelViewSet
 
 
 class TableViewPagination(PageNumberPagination):
     page_size = 10
 
 
-class TableView(viewsets.ModelViewSet):
+class TableView(CachedModelViewSet):
     permission_classes = [IsAuthenticated, HasCustomAPIKey, IsAdminOrRestaurant]
     serializer_class = TableSerializer
     pagination_class = TableViewPagination


### PR DESCRIPTION
## Summary
- configure Redis as Django cache backend
- add CachedModelViewSet for per-user response caching
- migrate restaurant viewsets to CachedModelViewSet to reuse cached results

## Testing
- `python -m py_compile MinMinBE/core/cache.py MinMinBE/alpha/settings.py MinMinBE/restaurant/branch/views.py MinMinBE/restaurant/combo/views.py MinMinBE/restaurant/discount/views.py MinMinBE/restaurant/menu/views.py MinMinBE/restaurant/menu_availability/views.py MinMinBE/restaurant/qr_code/views.py MinMinBE/restaurant/related_menu/views.py MinMinBE/restaurant/table/views.py MinMinBE/restaurant/tenant/views.py`
- `python manage.py test` *(fails: Could not find the GDAL library)*

------
https://chatgpt.com/codex/tasks/task_e_689b5ae5d36483238f120fdfb02d7438