### PR TITLE
Align bowl page styling with order summary

### DIFF
--- a/MinMinFECustomer/app/(protected)/cart/index.tsx
+++ b/MinMinFECustomer/app/(protected)/cart/index.tsx
@@ -287,7 +287,7 @@ export default function CartScreen() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: "#fff",
+    backgroundColor: "#FDFDFC",
   },
   safeArea: {
     flex: 1,
@@ -306,7 +306,7 @@ const styles = StyleSheet.create({
     borderRadius: 25,
   },
   appbar: {
-    backgroundColor: "#ffffff",
+    backgroundColor: "#FDFDFC",
   },
   appbarTitle: {
     fontWeight: "700",
@@ -338,7 +338,7 @@ const styles = StyleSheet.create({
   },
   scrollView: {
     flex: 1,
-    backgroundColor: "#fff",
+    backgroundColor: "#FDFDFC",
   },
   scrollContent: {
     padding: Platform.OS === "web" ? 10 : 6,
@@ -346,8 +346,8 @@ const styles = StyleSheet.create({
   },
   card: {
     marginBottom: 6,
-    backgroundColor: "#ffffff",
-    // borderRadius: 12,
+    backgroundColor: "#FDFDFC",
+    borderRadius: 12,
     ...Platform.select({
       web: {
         // boxShadow: "0 4px 12px rgba(0,0,0,0.1)",
@@ -409,13 +409,13 @@ const styles = StyleSheet.create({
     textAlign: "center",
   },
   fixedBottomContainer: {
-    backgroundColor: "#fff",
+    backgroundColor: "#FDFDFC",
     padding: 16,
     borderTopWidth: 1,
     borderTopColor: "#eee",
   },
   summaryCard: {
-    backgroundColor: "#ffffff",
+    backgroundColor: "#FDFDFC",
     borderRadius: 12,
     ...Platform.select({
       web: {
@@ -454,10 +454,12 @@ const styles = StyleSheet.create({
   },
   checkoutButton: {
     marginTop: 16,
-    borderRadius: 25,
-    width: 350,
-      
-    
+    borderRadius: 30,
+    width: 353,
+    height: 50,
+    alignSelf: "center",
+    alignContent: "center",
+    justifyContent: "center",
     ...Platform.select({
       web: {
         maxWidth: 353,


### PR DESCRIPTION
## Summary
- unify cart screen colors with order summary page
- match checkout button dimensions and radius to order summary

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run lint` *(fails: Unable to resolve path to module 'react-test-renderer'; warnings remain)*

------
https://chatgpt.com/codex/tasks/task_e_689b894525b88323ab0bc671c8f6098c