### PR TITLE
feat: support body and header per endpoint in URL hitter

### DIFF
--- a/MinMinBE/hit_urls.sh
+++ b/MinMinBE/hit_urls.sh
@@ -22,6 +22,11 @@ export TIMEOUT="20"
 # Delay between requests (seconds)
 export SLEEP_BETWEEN="0.05"
 
+# Sample credentials for POST requests (login, register, etc.)
+export TEST_EMAIL="user@example.com"
+export TEST_PASSWORD="Passw0rd!"
+export TEST_REFRESH="dummy-refresh"
+
 # Run the script
 echo "Running endpoint profiler against $BASE_URL..."
 python hit_urls.py


### PR DESCRIPTION
## Summary
- target only api* routes when profiling endpoints
- send endpoint-specific JSON payloads and headers for auth routes
- expose sample credential env vars in helper script

## Testing
- `pytest`
- `python -m py_compile hit_urls.py`

------
https://chatgpt.com/codex/tasks/task_e_689c3d4df6448323bc147ea7da44db02