### PR TITLE
Offload image compression to Celery tasks

### DIFF
--- a/MinMinBE/core/tasks.py
+++ b/MinMinBE/core/tasks.py
@@ -1,0 +1,50 @@
+from celery import shared_task
+from django.apps import apps
+from django.core.files.base import ContentFile
+from PIL import Image
+import io
+import os
+import logging
+
+logger = logging.getLogger(__name__)
+
+@shared_task
+def compress_image_task(model_label, instance_pk, field_name):
+    """Compress an image field to WEBP format asynchronously."""
+    Model = apps.get_model(model_label)
+    if Model is None:
+        logger.error("Model %s not found", model_label)
+        return
+    try:
+        instance = Model.objects.get(pk=instance_pk)
+    except Model.DoesNotExist:
+        logger.error("Instance %s of model %s not found", instance_pk, model_label)
+        return
+
+    field = getattr(instance, field_name, None)
+    if not field:
+        logger.error("Field %s not found on %s", field_name, model_label)
+        return
+    try:
+        if field.name.lower().endswith('.webp'):
+            return
+        with Image.open(field.path) as img:
+            if img.mode != 'RGB':
+                img = img.convert('RGB')
+            output = io.BytesIO()
+            img.save(
+                output,
+                format='WEBP',
+                quality=70,
+                method=6,
+                lossless=False,
+            )
+            output.seek(0)
+            base, _ = os.path.splitext(field.name)
+            new_filename = base + '.webp'
+            # remove original file
+            field.storage.delete(field.name)
+            field.save(new_filename, ContentFile(output.read()), save=False)
+            instance.save(update_fields=[field_name])
+    except Exception as exc:
+        logger.error("Error compressing image for %s %s: %s", model_label, instance_pk, exc)

--- a/MinMinBE/restaurant/menu/models.py
+++ b/MinMinBE/restaurant/menu/models.py
@@ -4,10 +4,7 @@ from django.core.exceptions import ValidationError
 from alpha.settings import MEDIA_ROOT
 import uuid
 import os
-from PIL import Image
-import io
 import logging
-from django.core.files.uploadedfile import InMemoryUploadedFile
 
 logger = logging.getLogger(__name__)
 
@@ -45,45 +42,14 @@ class Menu(models.Model):
     updated_at = models.DateTimeField(auto_now=True)
 
     def save(self, *args, **kwargs):
-        # Process image only if it's newly uploaded/changed
-        if self.image and not getattr(self.image, '_committed', True):
-            try:
-                # Open image using Pillow
-                with Image.open(self.image) as img:
-                    # Convert to RGB mode if needed (removes alpha channel)
-                    if img.mode != 'RGB':
-                        img = img.convert('RGB')
-                    
-                    # Create in-memory bytes buffer
-                    output = io.BytesIO()
-                    
-                    # Save as optimized WEBP with quality control
-                    img.save(
-                        output, 
-                        format='WEBP',
-                        quality=70,          # Quality setting (0-100)
-                        method=6,            # Best compression
-                        lossless=False       # Lossy compression for smaller size
-                    )
-                    output.seek(0)
-                    
-                    # Generate new filename with webp extension
-                    base, ext = os.path.splitext(self.image.name)
-                    filename = base + '.webp'
-                    
-                    # Replace original file with compressed version
-                    self.image = InMemoryUploadedFile(
-                        output,
-                        'ImageField',
-                        filename,
-                        'image/webp',
-                        output.getbuffer().nbytes,
-                        None
-                    )
-            except Exception as e:
-                logger.error(f"Error processing image for {self.name}: {str(e)}")
-        
+        image_changed = self.image and not getattr(self.image, '_committed', True)
         super().save(*args, **kwargs)
+        if image_changed:
+            try:
+                from core.tasks import compress_image_task
+                compress_image_task.delay('menu.Menu', str(self.pk), 'image')
+            except Exception as e:
+                logger.error(f"Error dispatching compression task for {self.name}: {str(e)}")
 
     def delete(self, using=None, keep_parents=False):
         from restaurant.discount.models import DiscountRule

--- a/MinMinBE/restaurant/tenant/models.py
+++ b/MinMinBE/restaurant/tenant/models.py
@@ -3,10 +3,7 @@ from django.core.exceptions import ValidationError
 from alpha.settings import MEDIA_ROOT
 import uuid
 import os
-from PIL import Image
-import io
 import logging
-from django.core.files.uploadedfile import InMemoryUploadedFile
 
 logger = logging.getLogger(__name__)
 
@@ -48,46 +45,14 @@ class Tenant(models.Model):
     updated_at = models.DateTimeField(auto_now=True)
 
     def save(self, *args, **kwargs):
-        # Process image only if it's newly uploaded/changed
-        if self.image and not getattr(self.image, '_committed', True):
-            try:
-                # Open image using Pillow
-                with Image.open(self.image) as img:
-                    # Convert to RGB mode if needed (removes alpha channel)
-                    if img.mode != 'RGB':
-                        img = img.convert('RGB')
-                    
-                    # Create in-memory bytes buffer
-                    output = io.BytesIO()
-                    
-                    # Save as optimized WEBP with quality control
-                    img.save(
-                        output, 
-                        format='WEBP',
-                        quality=70,          # Quality setting (0-100)
-                        method=6,            # Best compression
-                        lossless=False       # Lossy compression for smaller size
-                    )
-                    output.seek(0)
-                    
-                    # Generate new filename with webp extension
-                    base, ext = os.path.splitext(self.image.name)
-                    filename = base + '.webp'
-                    
-                    # Replace original file with compressed version
-                    self.image = InMemoryUploadedFile(
-                        output,
-                        'ImageField',
-                        filename,
-                        'image/webp',
-                        output.getbuffer().nbytes,
-                        None
-                    )
-            except Exception as e:
-                logger.error(f"Error processing image for {self.restaurant_name}: {str(e)}")
-                # If processing fails, keep the original image
-        
+        image_changed = self.image and not getattr(self.image, '_committed', True)
         super().save(*args, **kwargs)
+        if image_changed:
+            try:
+                from core.tasks import compress_image_task
+                compress_image_task.delay('tenant.Tenant', str(self.pk), 'image')
+            except Exception as e:
+                logger.error(f"Error dispatching compression task for {self.restaurant_name}: {str(e)}")
 
     def delete(self, using = None, keep_parents =False):
         if (self.tenant_carts.exists() or 


### PR DESCRIPTION
## Summary
- Add reusable `compress_image_task` to handle WEBP compression asynchronously via Celery
- Dispatch compression jobs after saving images for users, posts, tenants, and menus
- Clean up model imports and remove in-request image processing

## Testing
- `python manage.py test` *(fails: Could not find the GDAL library)*
- `python -m py_compile accounts/models.py feed/models.py restaurant/tenant/models.py restaurant/menu/models.py core/tasks.py`


------
https://chatgpt.com/codex/tasks/task_e_689c95ecbf30832393a43f0fc38241fc