### PR TITLE
feat: load settings from aws secrets and ssm

### DIFF
--- a/MinMinBE/core/redis_client.py
+++ b/MinMinBE/core/redis_client.py
@@ -1,8 +1,6 @@
+import os
 import redis
+from django.conf import settings
 
-redis_client = redis.StrictRedis(
-    host='localhost',
-    port=6379,
-    db=0,
-    decode_responses=True
-)
+redis_url = getattr(settings, 'REDIS_URL', os.getenv('REDIS_URL', 'redis://127.0.0.1:6379/0'))
+redis_client = redis.StrictRedis.from_url(redis_url, decode_responses=True)

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ MinMin is a full-stack platform for restaurant ordering and management. The back
    source venv/bin/activate
    pip install -r requirements.txt
    ```
-3. Provide required environment variables such as `SECRET_KEY`, database credentials (`DB_NAME`, `DB_USER`, `DB_PASSWORD`, `DB_HOST`, `DB_PORT`) and any email/OAuth keys referenced in `alpha/settings.py`.
+3. Provide required environment variables such as `SECRET_KEY`, database credentials (`DB_NAME`, `DB_USER`, `DB_PASSWORD`, `DB_HOST`, `DB_PORT`) and any email/OAuth keys referenced in `alpha/settings.py`. In staging, these values are automatically loaded from AWS Secrets Manager and SSM Parameter Store (paths under `minmin/stg/*`), so a local `.env` file is only necessary for development.
 4. Apply migrations, initialize an admin user, and start the development server:
    ```bash
    python manage.py migrate


### PR DESCRIPTION
## Summary
- load Django secret key, database credentials and API keys from AWS Secrets Manager
- fetch staging configuration such as allowed hosts, redis url and bucket from SSM Parameter Store
- use shared Redis URL in settings and client helper

## Testing
- `python manage.py test` *(fails: Could not find the GDAL library)*

------
https://chatgpt.com/codex/tasks/task_e_689ca98bbc2c8323bd90b9f977c9c9be