### PR TITLE
Add backend Dockerfile for container builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+# Use Python 3.12 slim base image
+FROM python:3.12-slim
+
+# Set working directory
+WORKDIR /app
+
+# Install Python dependencies
+COPY MinMinBE/requirements.txt ./requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy backend source code
+COPY MinMinBE/ ./
+
+# Expose Django port
+EXPOSE 8000
+
+# Run the application with Gunicorn
+CMD ["gunicorn", "alpha.wsgi:application", "--bind", "0.0.0.0:8000"]


### PR DESCRIPTION
## Summary
- add Dockerfile to containerize the Django backend

## Testing
- `python manage.py test` *(fails: Could not find the GDAL library)*
- `docker build .` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_689f3360df4c8323ae30939f9f14df61