### PR TITLE
Set noninteractive apt frontend for Docker builds

### DIFF
--- a/MinMinBE/Dockerfile
+++ b/MinMinBE/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1
 # Python base
 FROM python:3.12-slim
+ARG DEBIAN_FRONTEND=noninteractive
 
 # App/env settings
 ENV PYTHONDONTWRITEBYTECODE=1 \

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -6,6 +6,7 @@ COPY src/requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 
 FROM python:3.11-slim
+ARG DEBIAN_FRONTEND=noninteractive
 WORKDIR /app
 RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/* \
     && addgroup --system app && adduser --system --ingroup app app


### PR DESCRIPTION
## Summary
- avoid debconf warnings by setting `DEBIAN_FRONTEND=noninteractive` before `apt-get` in Dockerfiles

## Testing
- `docker build backend` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a09ab5a5888323b285ec01f33d41b3