### PR TITLE
docs: document EB deploy role permissions

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -27,6 +27,15 @@ Instances assume an IAM role with permissions to read parameters:
 
 Attach the role to the environment's instance profile.
 
+#### GitHub Actions
+
+The deployment workflow in `.github/workflows/deploy-backend-eb.yml` assumes a
+separate IAM role. That role must be able to create a new Elastic Beanstalk
+application version and update the target environment. Attach a policy such as
+[`github-actions-eb-policy.json`](github-actions-eb-policy.json) that permits
+`elasticbeanstalk:CreateApplicationVersion` and
+`elasticbeanstalk:UpdateEnvironment` on the relevant resources.
+
 ### Deployment
 
 GitHub Actions builds the Docker image, uploads an application version and updates the environment. After deployment, `/healthz` is checked for success.

--- a/infra/github-actions-eb-policy.json
+++ b/infra/github-actions-eb-policy.json
@@ -1,0 +1,18 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "ElasticBeanstalkDeploy",
+      "Effect": "Allow",
+      "Action": [
+        "elasticbeanstalk:CreateApplicationVersion",
+        "elasticbeanstalk:UpdateEnvironment"
+      ],
+      "Resource": [
+        "arn:aws:elasticbeanstalk:*:*:application/*",
+        "arn:aws:elasticbeanstalk:*:*:applicationversion/*",
+        "arn:aws:elasticbeanstalk:*:*:environment/*/*"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- document IAM requirements for GitHub Actions Elastic Beanstalk deployments
- add sample IAM policy for the deployment role

## Testing
- `python -m py_compile $(git ls-files '*.py')` *(fails: the following arguments are required: filenames)*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0ac113e888323bba9762d71a89cf4