### PR TITLE
Ensure ECR repository exists before backend deployment

### DIFF
--- a/.github/workflows/deploy-backend-eb.yml
+++ b/.github/workflows/deploy-backend-eb.yml
@@ -21,6 +21,10 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
       - name: Login to Amazon ECR
         uses: aws-actions/amazon-ecr-login@v2
+      - name: Ensure ECR repository exists
+        run: |
+          REPO_NAME=$(echo "${{ secrets.ECR_BACKEND }}" | cut -d'/' -f2)
+          aws ecr describe-repositories --repository-names "$REPO_NAME" || aws ecr create-repository --repository-name "$REPO_NAME"
       - name: Build and push image
         run: |
           IMAGE_URI=${{ secrets.ECR_BACKEND }}:${GITHUB_SHA}

--- a/infra/SECRETS.md
+++ b/infra/SECRETS.md
@@ -5,6 +5,7 @@ GitHub repository secrets required:
 - `AWS_ROLE_TO_ASSUME`
 - `AWS_REGION`
 - `ECR_BACKEND`
+- `ECR repository name` – `minmin-backend` (must exist or be created)
 - `EB_APP`
 - `EB_ENV_MAIN`
 - `EB_ENV_DEVELOP`


### PR DESCRIPTION
## Summary
- ensure ECR repository is created before pushing backend image
- document required ECR repository name in infrastructure secrets

## Testing
- `npm test` (fails: ENOENT package.json)
- `yamllint .github/workflows/deploy-backend-eb.yml` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68a0a522eb988323889d258fdf7b347b