### PR TITLE
Ensure EB deployment bucket exists before upload

### DIFF
--- a/.github/workflows/deploy-backend-eb.yml
+++ b/.github/workflows/deploy-backend-eb.yml
@@ -52,6 +52,11 @@ jobs:
             ]
           }
           EOD
+      - name: Ensure EB S3 bucket exists
+        run: |
+          BUCKET=${{ secrets.EB_APP }}
+          aws s3api head-bucket --bucket "$BUCKET" 2>/dev/null || \
+            aws s3api create-bucket --bucket "$BUCKET" --region ${{ secrets.AWS_REGION }} --create-bucket-configuration LocationConstraint=${{ secrets.AWS_REGION }}
       - name: Bundle and deploy
         run: |
           ZIP=backend-${GITHUB_SHA}.zip


### PR DESCRIPTION
## Summary
- prevent Elastic Beanstalk deployments from failing by creating the S3 bucket if needed

## Testing
- `yamllint .github/workflows/deploy-backend-eb.yml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0b80503b8832382424725e77913ea