### PR TITLE
fix(ci): deploy new EB versions and reuse unique labels

### DIFF
--- a/.github/workflows/deploy-backend-eb.yml
+++ b/.github/workflows/deploy-backend-eb.yml
@@ -62,12 +62,12 @@ jobs:
             aws s3api create-bucket --bucket "$EB_BUCKET" --region ${{ secrets.AWS_REGION }} --create-bucket-configuration LocationConstraint=${{ secrets.AWS_REGION }}
       - name: Bundle and deploy
         run: |
-          VERSION_LABEL="${GITHUB_SHA}-${GITHUB_RUN_NUMBER}"
+          VERSION_LABEL="${GITHUB_SHA}-${GITHUB_RUN_NUMBER}-${GITHUB_RUN_ATTEMPT}"
           ZIP=backend-$VERSION_LABEL.zip
           zip -r $ZIP Dockerrun.aws.json
           aws s3 cp $ZIP s3://$EB_BUCKET/$ZIP
-          aws elasticbeanstalk create-application-version --application-name $EB_APP --version-label $VERSION_LABEL --source-bundle S3Bucket=$EB_BUCKET,S3Key=$ZIP || \
-            aws elasticbeanstalk update-environment --application-name $EB_APP --environment-name $EB_ENV --version-label $VERSION_LABEL
+          aws elasticbeanstalk create-application-version --application-name $EB_APP --version-label $VERSION_LABEL --source-bundle S3Bucket=$EB_BUCKET,S3Key=$ZIP || echo "Application version already exists"
+          aws elasticbeanstalk update-environment --environment-name $EB_ENV --version-label $VERSION_LABEL
       - name: Post-deploy health check
         run: |
           curl -f https://${EB_ENV}.elasticbeanstalk.${{ secrets.AWS_REGION }}.amazonaws.com/healthz


### PR DESCRIPTION
## Summary
- ensure EB deployment workflow uses unique version label per run attempt
- always update environment after registering application version

## Testing
- `pip install yamllint` *(failed: Could not find a version that satisfies the requirement yamllint)*
- `yamllint .github/workflows/deploy-backend-eb.yml` *(command not found)*
- `npm test` *(failed: enoent Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0d366661083239eea20ca6953a91e