### PR TITLE
fix: ensure EB app name specified for backend deploy

### DIFF
--- a/.github/workflows/deploy-backend-eb.yml
+++ b/.github/workflows/deploy-backend-eb.yml
@@ -66,8 +66,14 @@ jobs:
           ZIP=backend-$VERSION_LABEL.zip
           zip -r $ZIP Dockerrun.aws.json
           aws s3 cp $ZIP s3://$EB_BUCKET/$ZIP
-          aws elasticbeanstalk create-application-version --application-name $EB_APP --version-label $VERSION_LABEL --source-bundle S3Bucket=$EB_BUCKET,S3Key=$ZIP || echo "Application version already exists"
-          aws elasticbeanstalk update-environment --environment-name $EB_ENV --version-label $VERSION_LABEL
+          aws elasticbeanstalk create-application-version \
+            --application-name "$EB_APP" \
+            --version-label "$VERSION_LABEL" \
+            --source-bundle S3Bucket="$EB_BUCKET",S3Key="$ZIP" || echo "Application version already exists"
+          aws elasticbeanstalk update-environment \
+            --application-name "$EB_APP" \
+            --environment-name "$EB_ENV" \
+            --version-label "$VERSION_LABEL"
       - name: Post-deploy health check
         run: |
           curl -f https://${EB_ENV}.elasticbeanstalk.${{ secrets.AWS_REGION }}.amazonaws.com/healthz


### PR DESCRIPTION
## Summary
- ensure application name passed to Elastic Beanstalk deploy
- include application name when updating environment

## Testing
- `npx prettier --check .github/workflows/deploy-backend-eb.yml`

------
https://chatgpt.com/codex/tasks/task_e_68a1f87dc0708323858eab44af79d42e