### PR TITLE
fix: validate EB app name before deploy

### DIFF
--- a/.github/workflows/deploy-backend-eb.yml
+++ b/.github/workflows/deploy-backend-eb.yml
@@ -62,12 +62,22 @@ jobs:
             aws s3api create-bucket --bucket "$EB_BUCKET" --region ${{ secrets.AWS_REGION }} --create-bucket-configuration LocationConstraint=${{ secrets.AWS_REGION }}
       - name: Bundle and deploy
         run: |
+          if [ -z "$EB_APP" ]; then
+            echo "EB_APP is not set" >&2
+            exit 1
+          fi
           VERSION_LABEL="${GITHUB_SHA}-${GITHUB_RUN_NUMBER}-${GITHUB_RUN_ATTEMPT}"
           ZIP=backend-$VERSION_LABEL.zip
           zip -r $ZIP Dockerrun.aws.json
           aws s3 cp $ZIP s3://$EB_BUCKET/$ZIP
-          aws elasticbeanstalk create-application-version --application-name $EB_APP --version-label $VERSION_LABEL --source-bundle S3Bucket=$EB_BUCKET,S3Key=$ZIP || echo "Application version already exists"
-          aws elasticbeanstalk update-environment --environment-name $EB_ENV --version-label $VERSION_LABEL
+          aws elasticbeanstalk create-application-version \
+            --application-name "$EB_APP" \
+            --version-label "$VERSION_LABEL" \
+            --source-bundle S3Bucket="$EB_BUCKET",S3Key="$ZIP"
+          aws elasticbeanstalk update-environment \
+            --application-name "$EB_APP" \
+            --environment-name "$EB_ENV" \
+            --version-label "$VERSION_LABEL"
       - name: Post-deploy health check
         run: |
           curl -f https://${EB_ENV}.elasticbeanstalk.${{ secrets.AWS_REGION }}.amazonaws.com/healthz


### PR DESCRIPTION
## Summary
- ensure backend deploy fails early when Elastic Beanstalk application name is missing
- remove misleading "application version already exists" message so AWS CLI errors surface

## Testing
- `npx prettier --check .github/workflows/deploy-backend-eb.yml`


------
https://chatgpt.com/codex/tasks/task_e_68a1f87dc0708323858eab44af79d42e