### PR TITLE
Install gunicorn in backend container

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -3,7 +3,8 @@
 FROM python:3.11-slim as builder
 WORKDIR /app
 COPY src/requirements.txt ./
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt && \
+    pip install --no-cache-dir gunicorn
 
 FROM python:3.11-slim
 ARG DEBIAN_FRONTEND=noninteractive

--- a/backend/src/requirements.txt
+++ b/backend/src/requirements.txt
@@ -1,1 +1,2 @@
-# add backend requirements here
+# Backend dependencies
+gunicorn


### PR DESCRIPTION
## Summary
- Install gunicorn during backend image build and list it in requirements

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a2250954708323b94c3dc0b6dab5e5