### PR TITLE
fix: support postgis url in entrypoint

### DIFF
--- a/MinMinBE/entrypoint.sh
+++ b/MinMinBE/entrypoint.sh
@@ -3,7 +3,10 @@ set -e
 
 if [ -n "$DATABASE_URL" ]; then
   echo "Waiting for Postgres..."
-  until pg_isready -d "$DATABASE_URL" > /dev/null 2>&1; do
+  # pg_isready does not understand the "postgis" scheme, so replace it
+  # with the standard postgres scheme before checking connectivity.
+  DB_CHECK_URL="${DATABASE_URL/postgis/postgres}"
+  until pg_isready -d "$DB_CHECK_URL" > /dev/null 2>&1; do
     sleep 1
   done
 fi


### PR DESCRIPTION
## Summary
- handle `postgis://` URLs when waiting for Postgres in entrypoint

## Testing
- `cd MinMinBE
set -a; . ./.env; set +a; DATABASE_URL=sqlite:///test.sqlite3 python manage.py test` *(fails: Could not find the GDAL library)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c335f9f483238dc11f80893be916