### PR TITLE
fix: replace bash-specific substitution in entrypoint

### DIFF
--- a/MinMinBE/entrypoint.sh
+++ b/MinMinBE/entrypoint.sh
@@ -5,7 +5,7 @@ if [ -n "$DATABASE_URL" ]; then
   echo "Waiting for Postgres..."
   # pg_isready does not understand the "postgis" scheme, so replace it
   # with the standard postgres scheme before checking connectivity.
-  DB_CHECK_URL="${DATABASE_URL/postgis/postgres}"
+  DB_CHECK_URL="$(echo "$DATABASE_URL" | sed -e 's/^postgis:/postgres:/')"
   until pg_isready -d "$DB_CHECK_URL" > /dev/null 2>&1; do
     sleep 1
   done


### PR DESCRIPTION
## Summary
- replace bash-only parameter expansion in entrypoint with sed for POSIX sh compatibility

## Testing
- `sh -n MinMinBE/entrypoint.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a4c53e47648323ba67ce8ea39ff713