### PR TITLE
chore: verify EB env vars before deploy

### DIFF
--- a/.github/workflows/deploy-be.yml
+++ b/.github/workflows/deploy-be.yml
@@ -32,6 +32,18 @@ jobs:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ env.AWS_REGION }}
 
+      - name: Verify EB environment variables
+        run: |
+          REQUIRED_VARS=(DJANGO_SECRET_KEY DATABASE_URL)
+          aws elasticbeanstalk describe-configuration-settings \
+            --application-name "$EB_APP" \
+            --environment-name "$EB_ENV" \
+            --query "ConfigurationSettings[0].OptionSettings[?Namespace=='aws:elasticbeanstalk:application:environment'].[OptionName,Value]" \
+            --output text | awk '{print $1"="$2}' > /tmp/env.txt
+          for v in "${REQUIRED_VARS[@]}"; do
+            grep -q "^$v=" /tmp/env.txt || { echo "Missing $v in EB env"; exit 1; }
+          done
+
       - name: Login to ECR
         run: |
           aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin $ECR_BACKEND


### PR DESCRIPTION
## Summary
- check for critical Elastic Beanstalk environment variables before updating the backend environment

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement aiohappyeyeballs==2.4.3)*
- `pytest` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a57e86d8c883239e030e90f6438f2c