### PR TITLE
fix: correct YAML indentation in backend deploy workflow

### DIFF
--- a/.github/workflows/deploy-be.yml
+++ b/.github/workflows/deploy-be.yml
@@ -59,22 +59,22 @@ jobs:
       - name: Generate EB options
         run: |
           python3 - <<'PYTHON'
-import json, pathlib
-env_file = pathlib.Path('MinMinBE/.env')
-options = []
-for line in env_file.read_text().splitlines():
-    line = line.strip()
-    if not line or line.startswith('#') or '=' not in line:
-        continue
-    key, value = line.split('=', 1)
-    options.append({
-        "Namespace": "aws:elasticbeanstalk:application:environment",
-        "OptionName": key,
-        "Value": value
-    })
-with open('options.json', 'w') as f:
-    json.dump(options, f)
-PYTHON
+          import json, pathlib
+          env_file = pathlib.Path('MinMinBE/.env')
+          options = []
+          for line in env_file.read_text().splitlines():
+              line = line.strip()
+              if not line or line.startswith('#') or '=' not in line:
+                  continue
+              key, value = line.split('=', 1)
+              options.append({
+                  "Namespace": "aws:elasticbeanstalk:application:environment",
+                  "OptionName": key,
+                  "Value": value
+              })
+          with open('options.json', 'w') as f:
+              json.dump(options, f)
+          PYTHON
 
       - name: Prepare Dockerrun
         run: |


### PR DESCRIPTION
## Summary
- fix indentation of the Python here-doc in deploy-be workflow
- ensure YAML parses correctly

## Testing
- `python - <<'PY'
import yaml, sys
with open('.github/workflows/deploy-be.yml') as f:
    yaml.safe_load(f)
print('YAML OK')
PY`
- `yamllint .github/workflows/deploy-be.yml` *(fails: command not found; network 403 during installation)*

------
https://chatgpt.com/codex/tasks/task_e_68a7333a476c8323bec1a4a8342873f5