### PR TITLE
Install GeoDjango runtime libraries in API Docker image

### DIFF
--- a/MinMinBE/Dockerfile
+++ b/MinMinBE/Dockerfile
@@ -9,8 +9,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libpq-dev \
     postgresql-client \
     gdal-bin \
+    libgdal-dev \
+    libgeos-dev \
+    libproj-dev \
     curl \
     && rm -rf /var/lib/apt/lists/*
+
+ENV GDAL_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/libgdal.so \
+    GEOS_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/libgeos_c.so
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- install PostGIS/GeoDjango system packages (GDAL, GEOS, PROJ) in the API Docker image
- export GDAL and GEOS library paths so Django can import the spatial backends successfully at runtime

## Testing
- not run (Docker is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e37b1d52e48323b575a26933fe73c4