### PR TITLE
Ensure PostGIS extension exists before starting API

### DIFF
--- a/MinMinBE/entrypoint.sh
+++ b/MinMinBE/entrypoint.sh
@@ -5,12 +5,18 @@ mkdir -p /app/media/images || true
 
 if [ -n "$DATABASE_URL" ]; then
   echo "Waiting for Postgres..."
-  # pg_isready does not understand the "postgis" scheme, so replace it
-  # with the standard postgres scheme before checking connectivity.
-  DB_CHECK_URL="$(echo "$DATABASE_URL" | sed -e 's/^postgis:/postgres:/')"
+  # pg_isready and psql understand the standard postgresql scheme. Convert any
+  # postgis:// URL so we can reuse the same connection string for both tools.
+  DB_CHECK_URL="$(echo "$DATABASE_URL" | sed -e 's/^postgis:/postgresql:/')"
   until pg_isready -d "$DB_CHECK_URL" > /dev/null 2>&1; do
     sleep 1
   done
+
+  echo "Ensuring PostGIS extension is installed..."
+  # Using psql here avoids importing Django before the database schema exists
+  # and guarantees the extension is created even if the database volume was
+  # initialised without it.
+  psql "$DB_CHECK_URL" -v ON_ERROR_STOP=1 -c "CREATE EXTENSION IF NOT EXISTS postgis;"
 fi
 
 python manage.py migrate --noinput


### PR DESCRIPTION
## Summary
- wait for PostgreSQL using a postgresql:// URL so both pg_isready and psql can reuse it
- ensure the PostGIS extension is created with psql before running migrations

## Testing
- not run (network restrictions prevent installing Python dependencies)


------
https://chatgpt.com/codex/tasks/task_e_68e38044d3dc8323ac9098ab0aabecf1